### PR TITLE
Move AWS Doc  to Integrations page

### DIFF
--- a/docs/aws/kinesis-streams.mdx
+++ b/docs/aws/kinesis-streams.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Ingest AWS Kinesis Streams"
+title: "AWS CloudWatch"
 description: ""
 ---
 

--- a/mint.json
+++ b/mint.json
@@ -82,16 +82,9 @@
         {
           "group": "Metrics",
           "pages": [
-            "docs/data-ingestion-apis/opentelemetry-metrics",
-            "docs/data-ingestion-apis/datadog-ingestion"
+            "docs/data-ingestion-apis/opentelemetry-metrics"
           ]
         }
-      ]
-    },
-    {
-      "group": "AWS",
-      "pages": [
-        "docs/aws/kinesis-streams"
       ]
     },
     {
@@ -162,7 +155,8 @@
         "docs/integrations/mongodb-integration",
         "docs/integrations/mysql-integration",
         "docs/integrations/redis-integration",
-        "docs/integrations/prometheus-integration"
+        "docs/integrations/prometheus-integration",
+        "docs/aws/kinesis-streams"
       ]
     },
     {


### PR DESCRIPTION
Completely removed AWS nested folder and placed file in Integrations nested folder. Renamed Doc from "kinesis" to "cloudwatch"