### PR TITLE
APM Hotfix

### DIFF
--- a/apm-configuration/go.mdx
+++ b/apm-configuration/go.mdx
@@ -467,9 +467,9 @@ Continuous profiling captures real-time performance insights from your applicati
 
 For more information on Continuous Profiling, navigate to [Workflows](/workflow/profiling) to find out more.
 
-|     |     |     |     |    |      |     |
-| :-: | :-: | :-: | :-: |:-: | :-: | :-: |
-|  __Object Allocation__   |   __Memory Allocation__  |   __Objects in Use__  |  __Memory in Use__   |  __CPU Usage__  | __Wall-clock time__ | __Reference__ |
-|         ✅               |      ✅                  |       ✅              |       ✅             |       ✅        |          ✖️           |        ✖️       |
+|     |     |     |     |    |           |
+| :-: | :-: | :-: | :-: |:-: | :-: | 
+|  __Object Allocation__   |   __Memory Allocation__  |   __Objects in Use__  |  __Memory in Use__   |  __CPU Usage__  | __Wall-clock time__ | 
+|         ✅               |      ✅                  |       ✅              |       ✅             |       ✅        |          ✖️           |        
 
 <Note> Need assistance or want to learn more about Middleware? Contact us at support[at]middleware.io. </Note>

--- a/apm-configuration/java.mdx
+++ b/apm-configuration/java.mdx
@@ -137,9 +137,9 @@ Continuous profiling captures real-time performance insights from your applicati
 
 For more information on Continuous Profiling, navigate to [Workflows](/workflow/profiling) to find out more.
 
-|     |     |     |     |    |      |     |
-| :-: | :-: | :-: | :-: |:-: | :-: | :-: |
-|  __Object Allocation__   |   __Memory Allocation__  |   __Objects in Use__  |  __Memory in Use__   |  __CPU Usage__  | __Wall-clock time__ | __Reference__ |
-|         ✖️                 |  ✖️                        |      ✖️                 |          ✖️            |         ✅      |            ✖️         |  ✖️             |
+|     |     |     |     |    |           |
+| :-: | :-: | :-: | :-: |:-: | :-: | 
+|  __Object Allocation__   |   __Memory Allocation__  |   __Objects in Use__  |  __Memory in Use__   |  __CPU Usage__  | __Wall-clock time__ | 
+|         ✖️                 |  ✖️                        |      ✖️                 |          ✖️            |         ✅      |            ✖️         |  
 
 <Note> Need assistance or want to learn more about Middleware? Contact us at support[at]middleware.io. </Note>

--- a/apm-configuration/next-js.mdx
+++ b/apm-configuration/next-js.mdx
@@ -174,10 +174,10 @@ Continuous profiling captures real-time performance insights from your applicati
 
 For more information on Continuous Profiling, navigate to [Workflows](/workflow/profiling) to find out more.
 
-|     |     |     |     |    |      |     |
-| :-: | :-: | :-: | :-: |:-: | :-: | :-: |
-|  __Object Allocation__   |   __Memory Allocation__  |   __Objects in Use__  |  __Memory in Use__   |  __CPU Usage__  | __Wall-clock time__ | __Reference__ |
-|        ✖️                  |     ✖️                     |          ✅           |         ✅           |         ✅      |          ✖️           |            ✖️   |
+|     |     |     |     |    |           |
+| :-: | :-: | :-: | :-: |:-: | :-: | 
+|  __Object Allocation__   |   __Memory Allocation__  |   __Objects in Use__  |  __Memory in Use__   |  __CPU Usage__  | __Wall-clock time__ | 
+|        ✖️                  |     ✖️                     |          ✅           |         ✅           |         ✅      |          ✖️           |            
 
 <Note> Need assistance or want to learn more about Middleware? Contact us at support[at]middleware.io. </Note>
 

--- a/apm-configuration/node-js.mdx
+++ b/apm-configuration/node-js.mdx
@@ -131,9 +131,9 @@ Continuous profiling captures real-time performance insights from your applicati
 
 For more information on Continuous Profiling, navigate to [Workflows](/workflow/profiling) to find out more.
 
-|     |     |     |     |    |      |     |
-| :-: | :-: | :-: | :-: |:-: | :-: | :-: |
-|  __Object Allocation__   |   __Memory Allocation__  |   __Objects in Use__  |  __Memory in Use__   |  __CPU Usage__  | __Wall-clock time__ | __Reference__ |
-|          ✖️                |        ✖️                  |           ✅          |       ✅             |       ✖️          |        ✖️             |      ✖️         |
+|     |     |     |     |    |           |
+| :-: | :-: | :-: | :-: |:-: | :-: | 
+|  __Object Allocation__   |   __Memory Allocation__  |   __Objects in Use__  |  __Memory in Use__   |  __CPU Usage__  | __Wall-clock time__ | 
+|          ✖️                |        ✖️                  |           ✅          |       ✅             |       ✖️          |        ✖️             |      
 
 <Note> Need assistance or want to learn more about Middleware? Contact us at support[at]middleware.io. </Note>

--- a/apm-configuration/python.mdx
+++ b/apm-configuration/python.mdx
@@ -158,10 +158,10 @@ Continuous profiling captures real-time performance insights from your applicati
 
 For more information on Continuous Profiling, navigate to [Workflows](/workflow/profiling) to find out more.
 
-|     |     |     |     |    |      |     |
-| :-: | :-: | :-: | :-: |:-: | :-: | :-: |
-|  __Object Allocation__   |   __Memory Allocation__  |   __Objects in Use__  |  __Memory in Use__   |  __CPU Usage__  | __Wall-clock time__ | __Reference__ |
-|        ✖️                  |    ✖️                      |      ✖️                 |        ✖️              |         ✅      |        ✖️             |          ✖️     |
+|     |     |     |     |    |           |
+| :-: | :-: | :-: | :-: |:-: | :-: | 
+|  __Object Allocation__   |   __Memory Allocation__  |   __Objects in Use__  |  __Memory in Use__   |  __CPU Usage__  | __Wall-clock time__ | 
+|        ✖️                  |    ✖️                      |      ✖️                 |        ✖️              |         ✅      |        ✖️             |          
 
 <Note> Need assistance or want to learn more about Middleware? Contact us at support[at]middleware.io. </Note>
 

--- a/apm-configuration/ruby.mdx
+++ b/apm-configuration/ruby.mdx
@@ -101,9 +101,9 @@ Continuous profiling captures real-time performance insights from your applicati
 
 For more information on Continuous Profiling, navigate to [Workflows](/workflow/profiling) to find out more.
 
-|     |     |     |     |    |      |     |
-| :-: | :-: | :-: | :-: |:-: | :-: | :-: |
-|  __Object Allocation__   |   __Memory Allocation__  |   __Objects in Use__  |  __Memory in Use__   |  __CPU Usage__  | __Wall-clock time__ | __Reference__ |
-|        ✖️                  |   ✖️                       |      ✖️                 |          ✖️            |        ✅       |           ✖️          |    ✖️           |
+|     |     |     |     |    |           |
+| :-: | :-: | :-: | :-: |:-: | :-: | 
+|  __Object Allocation__   |   __Memory Allocation__  |   __Objects in Use__  |  __Memory in Use__   |  __CPU Usage__  | __Wall-clock time__ | 
+|        ✖️                  |   ✖️                       |      ✖️                 |          ✖️            |        ✅       |           ✖️          |
 
 <Note> Need assistance or want to learn more about Middleware? Contact us at support[at]middleware.io. </Note>


### PR DESCRIPTION
Removing the Reference column from Continuous Profiling section of the APM