### PR TITLE
Continuous Profiling Matrix

### DIFF
--- a/apm-configuration/cloudflare.mdx
+++ b/apm-configuration/cloudflare.mdx
@@ -65,6 +65,6 @@ sdk.logger.warn("warn test")
 
 Continuous profiling captures real-time performance insights from your application to enable rapid identification of resource allocation, bottlenecks, and more. The following table describes the available features offered by the continuous profiler for the Cloudflare APM.
 
-Continuous Profiling for the Cloudflare APM is not yet available; reach out to our support team if you'd like more information. To learn more about Continuous Profiling, see examples in our [Workflows](/workflow/profiling) section.
+Continuous Profiling for the Cloudflare APM is not yet available; reach out to our support team if you'd like more information. Navigate to the [Continuous Profiling](https://docs.middleware.io/workflow/profiling#continuous-profiling) section to learn more about using Continuous Profiling with our other APMs.
 
 <Note> Need assistance or want to learn more about Middleware? Contact us at support[at]middleware.io. </Note>

--- a/apm-configuration/dotnet.mdx
+++ b/apm-configuration/dotnet.mdx
@@ -75,8 +75,6 @@ chmod +x $HOME/.mw-dotnet-auto/instrument.sh
 
 # Continuous Profiling
 
-Continuous profiling captures real-time performance insights from your application to enable rapid identification of resource allocation, bottlenecks, and more. The following table describes the available features offered by the continuous profiler for the .NET APM.
-
-Continuous Profiling for the .NET APM is not yet available; reach out to our support team if you'd like more information. To learn more about Continuous Profiling, see examples in our [Workflows](/workflow/profiling) section.
+Continuous profiling captures real-time performance insights from your application to enable rapid identification of resource allocation, bottlenecks, and more. Navigate to the [Continuous Profiling](https://docs.middleware.io/workflow/profiling#continuous-profiling) section to learn more about using Continuous Profiling with the .NET APM.
 
 <Note> Need assistance or want to learn more about Middleware? Contact us at support[at]middleware.io. </Note>

--- a/apm-configuration/go.mdx
+++ b/apm-configuration/go.mdx
@@ -450,13 +450,6 @@ app.get("/hello", (req, res) => {
 
 # Continuous Profiling
 
-Continuous profiling captures real-time performance insights from your application to enable rapid identification of resource allocation, bottlenecks, and more. The following table describes the available features offered by the continuous profiler for the Go APM.
-
-For more information on Continuous Profiling, navigate to [Workflows](/workflow/profiling) to find out more.
-
-|     |     |     |     |    |           |
-| :-: | :-: | :-: | :-: |:-: | :-: | 
-|  __Object Allocation__   |   __Memory Allocation__  |   __Objects in Use__  |  __Memory in Use__   |  __CPU Usage__  | __Wall-clock time__ | 
-|         ✅               |      ✅                  |       ✅              |       ✅             |       ✅        |          ✖️           |        
+Continuous profiling captures real-time performance insights from your application to enable rapid identification of resource allocation, bottlenecks, and more. Navigate to the [Continuous Profiling](https://docs.middleware.io/workflow/profiling#continuous-profiling) section to learn more about using Continuous Profiling with the Go APM.     
 
 <Note> Need assistance or want to learn more about Middleware? Contact us at support[at]middleware.io. </Note>

--- a/apm-configuration/java.mdx
+++ b/apm-configuration/java.mdx
@@ -133,13 +133,7 @@ MW_API_KEY={MW_API_KEY} java -javaagent:/PATH/TO/middleware-javaagent-{version}.
 
 # Continuous Profiling
 
-Continuous profiling captures real-time performance insights from your application to enable rapid identification of resource allocation, bottlenecks, and more. The following table describes the available features offered by the continuous profiler for the Java APM.
+Continuous profiling captures real-time performance insights from your application to enable rapid identification of resource allocation, bottlenecks, and more. Navigate to the [Continuous Profiling](https://docs.middleware.io/workflow/profiling#continuous-profiling) section to learn more about using Continuous Profiling with the Java APM.
 
-For more information on Continuous Profiling, navigate to [Workflows](/workflow/profiling) to find out more.
-
-|     |     |     |     |    |           |
-| :-: | :-: | :-: | :-: |:-: | :-: | 
-|  __Object Allocation__   |   __Memory Allocation__  |   __Objects in Use__  |  __Memory in Use__   |  __CPU Usage__  | __Wall-clock time__ | __Blocking Contentions__ | __Blocking Delays__ | __Bytes Allocated (TLAB)__ | __Objects Allocated (TLAB)__ |
-|         ✖️                 |  ✖️                        |      ✖️                 |          ✖️            |         ✅      |            ✖️         |           ✅      |         ✅      |         ✅      |         ✅      |
 
 <Note> Need assistance or want to learn more about Middleware? Contact us at support[at]middleware.io. </Note>

--- a/apm-configuration/next-js.mdx
+++ b/apm-configuration/next-js.mdx
@@ -168,14 +168,7 @@ export default async function handler(req, res) {
 
 # Continuous Profiling
 
-Continuous profiling captures real-time performance insights from your application to enable rapid identification of resource allocation, bottlenecks, and more. The following table describes the available features offered by the continuous profiler for the Next.js APM.
-
-For more information on Continuous Profiling, navigate to [Workflows](/workflow/profiling) to find out more.
-
-|     |     |     |     |    |           |
-| :-: | :-: | :-: | :-: |:-: | :-: | 
-|  __Object Allocation__   |   __Memory Allocation__  |   __Objects in Use__  |  __Memory in Use__   |  __CPU Usage__  | __Wall-clock time__ | 
-|        ✖️                  |     ✖️                     |          ✅           |         ✅           |         ✅      |          ✖️           |            
+Continuous profiling captures real-time performance insights from your application to enable rapid identification of resource allocation, bottlenecks, and more. Navigate to the [Continuous Profiling](https://docs.middleware.io/workflow/profiling#continuous-profiling) section to learn more about using Continuous Profiling with the Next.js APM.
 
 <Note> Need assistance or want to learn more about Middleware? Contact us at support[at]middleware.io. </Note>
 

--- a/apm-configuration/node-js.mdx
+++ b/apm-configuration/node-js.mdx
@@ -126,13 +126,6 @@ MW_AGENT_SERVICE=mw-service.mw-agent-ns.svc.cluster.local
 
 # Continuous Profiling
 
-Continuous profiling captures real-time performance insights from your application to enable rapid identification of resource allocation, bottlenecks, and more. The following table describes the available features offered by the continuous profiler for the Node.js APM.
-
-For more information on Continuous Profiling, navigate to [Workflows](/workflow/profiling) to find out more.
-
-|     |     |     |     |    |           |
-| :-: | :-: | :-: | :-: |:-: | :-: | 
-|  __Object Allocation__   |   __Memory Allocation__  |   __Objects in Use__  |  __Memory in Use__   |  __CPU Usage__  | __Wall-clock time__ | 
-|          ✖️                |        ✖️                  |           ✅          |       ✅             |       ✖️          |        ✖️             |      
+Continuous profiling captures real-time performance insights from your application to enable rapid identification of resource allocation, bottlenecks, and more. Navigate to the [Continuous Profiling](https://docs.middleware.io/workflow/profiling#continuous-profiling) section to learn more about using Continuous Profiling with the Node.js APM.   
 
 <Note> Need assistance or want to learn more about Middleware? Contact us at support[at]middleware.io. </Note>

--- a/apm-configuration/php.mdx
+++ b/apm-configuration/php.mdx
@@ -187,8 +187,8 @@ To ingest custom logs, utilize the following functions based on desired log seve
 
 # Continuous Profiling
 
-Continuous profiling captures real-time performance insights from your application to enable rapid identification of resource allocation, bottlenecks, and more. The following table describes the available features offered by the continuous profiler for the PHP APM.
+Continuous profiling captures real-time performance insights from your application to enable rapid identification of resource allocation, bottlenecks, and more. 
 
-Continuous Profiling for the PHP APM is not yet available; reach out to our support team if you'd like more information. To learn more about Continuous Profiling, see examples in our [Workflows](/workflow/profiling) section.
+Continuous Profiling for the Cloudflare APM is not yet available; reach out to our support team if you'd like more information. Navigate to the [Continuous Profiling](https://docs.middleware.io/workflow/profiling#continuous-profiling) section to learn more about using Continuous Profiling with our other APMs.
 
 <Note> Need assistance or want to learn more about Middleware? Contact us at support[at]middleware.io. </Note>

--- a/apm-configuration/python.mdx
+++ b/apm-configuration/python.mdx
@@ -154,14 +154,7 @@ MIDDLEWARE_CONFIG_FILE=./middleware.ini middleware-apm run python app.py
 
 # Continuous Profiling
 
-Continuous profiling captures real-time performance insights from your application to enable rapid identification of resource allocation, bottlenecks, and more. The following table describes the available features offered by the continuous profiler for the Python APM.
-
-For more information on Continuous Profiling, navigate to [Workflows](/workflow/profiling) to find out more.
-
-|     |     |     |     |    |           |
-| :-: | :-: | :-: | :-: |:-: | :-: | 
-|  __Object Allocation__   |   __Memory Allocation__  |   __Objects in Use__  |  __Memory in Use__   |  __CPU Usage__  | __Wall-clock time__ | 
-|        ✖️                  |    ✖️                      |      ✖️                 |        ✖️              |         ✅      |        ✖️             |          
+Continuous profiling captures real-time performance insights from your application to enable rapid identification of resource allocation, bottlenecks, and more. Navigate to the [Continuous Profiling](https://docs.middleware.io/workflow/profiling#continuous-profiling) section to learn more about using Continuous Profiling with the Python APM.     
 
 <Note> Need assistance or want to learn more about Middleware? Contact us at support[at]middleware.io. </Note>
 

--- a/apm-configuration/ruby.mdx
+++ b/apm-configuration/ruby.mdx
@@ -97,13 +97,6 @@ This guide walks you through setting up Application Performance Monitoring (APM)
 
 # Continuous Profiling
 
-Continuous profiling captures real-time performance insights from your application to enable rapid identification of resource allocation, bottlenecks, and more. The following table describes the available features offered by the continuous profiler for the Ruby APM.
-
-For more information on Continuous Profiling, navigate to [Workflows](/workflow/profiling) to find out more.
-
-|     |     |     |     |    |           |
-| :-: | :-: | :-: | :-: |:-: | :-: | 
-|  __Object Allocation__   |   __Memory Allocation__  |   __Objects in Use__  |  __Memory in Use__   |  __CPU Usage__  | __Wall-clock time__ | 
-|        ✖️                  |   ✖️                       |      ✖️                 |          ✖️            |        ✅       |           ✖️          |
+Continuous profiling captures real-time performance insights from your application to enable rapid identification of resource allocation, bottlenecks, and more. Navigate to the [Continuous Profiling](https://docs.middleware.io/workflow/profiling#continuous-profiling) section to learn more about using Continuous Profiling with the Ruby APM.
 
 <Note> Need assistance or want to learn more about Middleware? Contact us at support[at]middleware.io. </Note>

--- a/apm-configuration/vercel-integration.mdx
+++ b/apm-configuration/vercel-integration.mdx
@@ -169,14 +169,7 @@ export default async function handler(req, res) {
 
 # Continuous Profiling
 
-Continuous profiling captures real-time performance insights from your application to enable rapid identification of resource allocation, bottlenecks, and more. The following table describes the available features offered by the continuous profiler for the Vercel APM.
-
-For more information on Continuous Profiling, navigate to [Workflows](/workflow/profiling) to find out more.
-
-|     |     |     |     |    |      |     |
-| :-: | :-: | :-: | :-: |:-: | :-: | :-: |
-|  __Object Allocation__   |   __Memory Allocation__  |   __Objects in Use__  |  __Memory in Use__   |  __CPU Usage__  | __Wall-clock time__ | __Reference__ |
-|       ✖️                   |     ✖️                     |           ✅          |         ✅           |         ✅      |        ✖️             |            ✖️   |
+Continuous profiling captures real-time performance insights from your application to enable rapid identification of resource allocation, bottlenecks, and more. Navigate to the [Continuous Profiling](https://docs.middleware.io/workflow/profiling#continuous-profiling) section to learn more about using Continuous Profiling with the Vercel APM.
 
 # Troubleshooting
 

--- a/integrations/prometheus-integration.mdx
+++ b/integrations/prometheus-integration.mdx
@@ -5,7 +5,7 @@ Retrieve metrics from a Prometheus endpoint.
 
 # Prerequisites
 
-Middleware Host Agent (MW Agent) must be installed on your local machine. To install the MW Agent, see our [installation guide](/agent-installation/overview).
+Middleware Host Agent (MW Agent) must be installed on your local machine. To install the MW Agent, see our [Installation Guide](https://docs.middleware.io/agent-installation/overview).
 
 # Setup
 

--- a/workflow/profiling.mdx
+++ b/workflow/profiling.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Continuous Profiling with Python"
+title: "Continuous Profiling with Middleware"
 sidebarTitle: "Continuous Profiling"
 ---
 
@@ -7,17 +7,36 @@ When software applications are first built, they may initially meet our requirem
 
 <Note> Although this guide focuses on a Python-specific implementation, Middleware supports all major programming languages. You can find instructions for your language of choice in our [APM Documentation](https://docs.middleware.io/apm-configuration/apm_overview). </Note>
 
-# Profiling
+# What is Profiling?
 
 Profiling, in the context of software development, refers to the process of analyzing and measuring the performance characteristics of a program or system. 
 
 It involves using specialized tools known as application profiling tools to gather metrics like CPU usage, memory allocation, and execution time.
 
-# Continuous Profiling
+# What is Continuous Profiling?
 
 Continuous profiling takes things a step further by enabling real-time monitoring and detection of performance regressions. It allows developers to proactively address any emerging issues before they impact users. 
 
-Continuous Profiling can be done by setting up an Application Performance Monitoring (APM) tool like the one available from [Middleware](https://middleware.io/).
+Continuous Profiling can be set up easily using any of our [APMs](https://docs.middleware.io/apm-configuration/apm_overview). 
+
+# Continuous Profiling Support Matrix
+
+The following table shows what Continuous Profiling features are available per each APM:
+
+|     |     |     |     |    |           |
+| :- | :- | :-: | :-: |:-: | :-: | 
+|                             | __Profiling Query Type__                        |__Node.js__ | __Go__ | __Java__ | __Ruby__ | __.NET__ | __PHP__ | __Python__ | __Next.js__ | __Vercel__ | __Cloudflare__ | 
+| __Object Allocation__       | `memory:alloc_objects:count::`                  |       ✖️    |    ✅  |     ✖️    |    ✖️     |     ✖️    |    ✖️    |     ✖️      |    ✖️        |      ✖️     |         ✖️      |
+| __Memory Allocation__       | `memory:alloc_space:bytes::`                    |       ✖️    |    ✅  |    ✖️     |    ✖️     |     ✖️    |    ✖️    |     ✖️      |    ✖️        |      ✖️     |         ✖️      |
+| __Objects in Use__          | `memory:inuse_objects:count`                    |   ✅       |    ✅  |    ✖️     |    ✖️     |     ✖️    |    ✖️    |     ✖️      |    ✅       |      ✅    |        ✖️      |
+| __Memory in Use__           | `memory:inuse_space:bytes`                      |   ✅       |    ✅  |    ✖️     |    ✖️     |     ✖️    |    ✖️    |     ✖️      |    ✅       |      ✅    |      ✖️        |
+| __CPU Usage__               | `process_cpu:cpu:nanoseconds:cpu:nanoseconds`   |    ✖️       |✅      |✅        |✅        |     ✖️    |    ✖️    |          ✅|           ✅|          ✅|        ✖️       |
+| __Wall-clock time__         | `wall:wall:nanoseconds:cpu:nanoseconds`         |       ✖️    |   ✖️    |     ✖️    |    ✖️     |    ✅    |    ✖️    |     ✖️      |    ✖️        |      ✖️     |         ✖️      |
+| __Blocking Contentions__    | `block:contentions:count::`                     |  ✖️         |   ✖️    |    ✅    |    ✖️     |     ✖️    |    ✖️    |     ✖️      |    ✖️        |      ✖️     |         ✖️      |
+| __Blocking Delays__         | `block:delay:nanoseconds::`                     |  ✖️         |   ✖️    |✅        |    ✖️     |     ✖️    |    ✖️    |     ✖️      |    ✖️        |      ✖️     |         ✖️      |
+| __Bytes Allocated(TLAB)__   | `memory:alloc_in_new_tlab_bytes:bytes::`        |  ✖️         |   ✖️    |✅        |    ✖️     |     ✖️    |    ✖️    |     ✖️      |    ✖️        |      ✖️     |         ✖️      |
+| __Objects Allocated(TLAB)__ | `memory:alloc_in_new_tlab_objects:count::`      |  ✖️         |   ✖️    |✅        |    ✖️     |     ✖️    |    ✖️    |     ✖️      |    ✖️        |      ✖️     |         ✖️      |
+
 
 # Profiling A Flask Web Application
 


### PR DESCRIPTION
Removing matrices from individual APMs and placing large matrix in Continuous Profiling Doc.

Note: Need to make sure the Scala APM has the exact same Continuous Profiling features supported as the Java APM.