### PR TITLE
Fixing typos in ingestion controls

### DIFF
--- a/admin/settings/advanced.mdx
+++ b/admin/settings/advanced.mdx
@@ -78,10 +78,12 @@ Middleware provides users the ability to mask data at time of ingestion. This me
 Similar to the above attribute extraction, Data Masking is also based on standard regex rules.
 
 The setting will expect 2 inputs from users as shown in the image below
-1. A **Regex Pattern* for the keywords that users want to hide
+1. A **Regex Pattern** for the keywords that users want to hide
 2. A **Replacement Value**, e.g. `*****`, `HIDDEN`, etc.
 
 <img src="/images/settings/masking.png" />
+
+### Example Data Masking
 
 For example, if your log content looks like: 
 


### PR DESCRIPTION
I was missing a * and it made it look silly.